### PR TITLE
改用private构造器阻止对I18nUtils类的实例化

### DIFF
--- a/src/main/java/org/cfpa/i18nupdatemod/I18nUtils.java
+++ b/src/main/java/org/cfpa/i18nupdatemod/I18nUtils.java
@@ -20,8 +20,8 @@ import java.util.List;
 import static org.cfpa.i18nupdatemod.I18nUpdateMod.logger;
 
 public class I18nUtils {
-    public I18nUtils() {
-        throw new UnsupportedOperationException("no instance");
+    private I18nUtils() {
+        // No instantiation for this class is allowed
     }
 
     /**


### PR DESCRIPTION
原先I18nUtils用“在构造器里爆异常”的方法阻止对其的实例化。
但我觉得还是把这种检查放在编译期而非运行时要漂亮一点。